### PR TITLE
Fix socket

### DIFF
--- a/backend/sockets/index.js
+++ b/backend/sockets/index.js
@@ -21,6 +21,10 @@ module.exports = server => {
       onChangePage({ io, socket }, data)
     })
 
+    socket.on("client close", () => {
+      onDisconnect({ io, socket })
+    })
+
     socket.on("disconnect", () => {
       onDisconnect({ io, socket })
     })

--- a/frontend/src/components/Room/NavBar/index.tsx
+++ b/frontend/src/components/Room/NavBar/index.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from "react"
-import { Link } from "react-router-dom"
 
 import {
   ButtonsContainer,
@@ -21,6 +20,7 @@ type PropTypes = {
   filename: string
   handleChangePage(option: PageOption): void
   handleZoom(scaleOffset: number): void
+  handleClose(): void
 }
 
 const NavBar: React.FC<PropTypes> = ({
@@ -29,6 +29,7 @@ const NavBar: React.FC<PropTypes> = ({
   filename,
   handleChangePage,
   handleZoom,
+  handleClose,
 }): ReactElement => {
   return (
     <NavBarContainer>
@@ -53,9 +54,7 @@ const NavBar: React.FC<PropTypes> = ({
         </NavButton>
       </ButtonsContainer>
       <ButtonsContainer>
-        <Link to="/">
-          <CloseButton>Close</CloseButton>
-        </Link>
+        <CloseButton onClick={handleClose}>Close</CloseButton>
       </ButtonsContainer>
     </NavBarContainer>
   )

--- a/frontend/src/components/Room/index.tsx
+++ b/frontend/src/components/Room/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, ReactElement } from "react"
+import { useHistory } from "react-router-dom"
 
 import NavBar, { PageOption } from "./NavBar"
 import PDFView from "../PDFView"
@@ -70,6 +71,12 @@ const Room: React.FC<PropTypes> = ({ id, originalFilename }): ReactElement => {
     })
   }, [])
 
+  const history = useHistory()
+  const handleClose = (): void => {
+    socket.emit("client close")
+    history.push("/")
+  }
+
   const renderRoom = (): ReactElement => {
     return (
       <RoomBackground>
@@ -79,6 +86,7 @@ const Room: React.FC<PropTypes> = ({ id, originalFilename }): ReactElement => {
           filename={originalFilename}
           handleChangePage={handleChangePage}
           handleZoom={handleZoom}
+          handleClose={handleClose}
         />
         {pdfFile ? (
           <PDFView


### PR DESCRIPTION
Treat document close like disconnect:
- Handle close button instead of using `Link`
- Button close emits `client close` event
- Backend treats `client close` event like `disconnect`