### PR TITLE
Use ratio for mouse positions

### DIFF
--- a/frontend/src/utils/roundTo.ts
+++ b/frontend/src/utils/roundTo.ts
@@ -1,0 +1,7 @@
+export default (decimalPlaces: number): ((num: number) => number) => {
+  if (decimalPlaces < 0) throw new Error("decimalPlaces must be >= 0")
+  return (num: number): number => {
+    const multiplier = 10 ** decimalPlaces
+    return Math.round(num * multiplier) / multiplier
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "./backend/dist",
     "sourceMap": true,
     "target": "ES6",
-    "typeRoots": ["node_modules/@types"]
+    "typeRoots": ["node_modules/@types"],
+    "types": []
   },
   "exclude": ["node_modules"],
   "include": ["backend/src/**/*.ts"]


### PR DESCRIPTION
## What does this PR fix?
- Fixes #44 

## How?
- Send `mouseX` and `mouseY` as ratio of `ev.clientX / window.innerWidth` and `ev.clientY / window.innerHeight`
- Consume `mouseX` and `mouseY` as ratios
