### PR TITLE
Fix join order

### DIFF
--- a/backend/src/sockets/middlewares/checkRoom.ts
+++ b/backend/src/sockets/middlewares/checkRoom.ts
@@ -1,7 +1,7 @@
 import { Packet } from "socket.io"
 
 import { rooms } from "../cache"
-import { Connection, ChangePageData, JoinLeaveRoomData } from "../types"
+import { Connection, RoomData } from "../types"
 
 export default (
   connection: Connection,
@@ -15,7 +15,7 @@ export default (
     next()
   }
 
-  const data: ChangePageData | JoinLeaveRoomData = packet[1]
+  const data: RoomData = packet[1]
   const { roomID } = data
 
   const room = rooms[roomID]

--- a/backend/src/sockets/onCreateRoom.ts
+++ b/backend/src/sockets/onCreateRoom.ts
@@ -1,8 +1,8 @@
-import { rooms, usersMap } from "./cache"
-import { Connection, CreateRoomData, Room } from "./types"
+import { rooms } from "./cache"
+import { Connection, CreateRoomData, Room, RoomData } from "./types"
 
 export default (connection: Connection, data: CreateRoomData): void => {
-  const { socket } = connection
+  const { io, socket } = connection
   const { roomID, pdfUrl } = data
 
   const newRoom: Room = {
@@ -13,6 +13,7 @@ export default (connection: Connection, data: CreateRoomData): void => {
 
   rooms[roomID] = newRoom
 
-  // Cache user to room without joining room
-  usersMap[socket.id] = roomID
+  // Send private message back to room creator with roomID
+  const roomCreatedData: RoomData = { roomID }
+  io.to(socket.id).emit("room created", roomCreatedData)
 }

--- a/backend/src/sockets/onJoinRoom.ts
+++ b/backend/src/sockets/onJoinRoom.ts
@@ -22,11 +22,7 @@ export default (connection: Connection, data: RoomData): void => {
   const room = rooms[roomID]
 
   room.users.push(createUser(socket.id))
-
-  // Room creator is already cached, so don't redo work
-  if (!usersMap[socket.id]) {
-    usersMap[socket.id] = roomID
-  }
+  usersMap[socket.id] = roomID
 
   socket.join(roomID)
 

--- a/backend/src/sockets/onJoinRoom.ts
+++ b/backend/src/sockets/onJoinRoom.ts
@@ -1,7 +1,7 @@
 import { usersMap, rooms } from "./cache"
 import {
   Connection,
-  JoinLeaveRoomData,
+  RoomData,
   SyncDocData,
   SyncPageData,
   User,
@@ -16,7 +16,7 @@ const createUser = (id: string): User => {
   }
 }
 
-export default (connection: Connection, data: JoinLeaveRoomData): void => {
+export default (connection: Connection, data: RoomData): void => {
   const { io, socket } = connection
   const { roomID } = data
   const room = rooms[roomID]

--- a/backend/src/sockets/types.ts
+++ b/backend/src/sockets/types.ts
@@ -31,21 +31,18 @@ export type UsersMap = {
 // Client -> Server types//
 ///////////////////////////
 
-export type JoinLeaveRoomData = {
+export interface RoomData {
   roomID: string
 }
 
-export type CreateRoomData = {
-  roomID: string
+export interface CreateRoomData extends RoomData {
   pdfUrl: string
 }
-export type ChangePageData = {
-  roomID: string
+export interface ChangePageData extends RoomData {
   pageNum: number
 }
 
-export type MouseMoveData = {
-  roomID: string
+export interface MouseMoveData extends RoomData {
   mouseX: number
   mouseY: number
 }

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -10,9 +10,9 @@ const App: React.FC<{}> = (): ReactElement => {
     <Router>
       <Route exact path="/" component={Home} />
       <Route
-        path="/room=:id/file=:filename"
+        path="/room=:id/filename=:filename"
         render={({ match }): ReactElement => (
-          <Room id={match.params.id} originalFilename={match.params.filename} />
+          <Room id={match.params.id} filename={match.params.filename} />
         )}
       />
     </Router>

--- a/frontend/src/components/LinkModal/index.tsx
+++ b/frontend/src/components/LinkModal/index.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, FC, useRef, useEffect, useState } from "react"
-import { Redirect } from "react-router-dom"
 
-import { Cover, Code } from "../globalStyles"
+import { Code } from "../globalStyles"
 import {
+  LinkModalCover,
   Island,
   Input,
   ButtonsContainer,
@@ -19,9 +19,9 @@ type PropTypes = {
 }
 
 const LinkModal: FC<PropTypes> = ({ link }): ReactElement => {
-  const [ready, setReady] = useState(false)
+  const [show, setShow] = useState(true)
   const handleOK = (): void => {
-    setReady(true)
+    setShow(false)
   }
 
   const inputRef = useRef(null)
@@ -34,7 +34,7 @@ const LinkModal: FC<PropTypes> = ({ link }): ReactElement => {
 
   const renderModal = (): ReactElement => {
     return (
-      <Cover>
+      <LinkModalCover>
         <Island>
           <Title>You&rsquo;re all set!</Title>
           <Body>Copy and share the following link to invite others.</Body>
@@ -57,15 +57,11 @@ const LinkModal: FC<PropTypes> = ({ link }): ReactElement => {
             bucket with very limited read/write access.
           </Body>
         </Island>
-      </Cover>
+      </LinkModalCover>
     )
   }
 
-  return ready ? (
-    <Redirect push to={`${link.replace(window.location.toString(), "/")}`} />
-  ) : (
-    renderModal()
-  )
+  return show ? renderModal() : null
 }
 
 export default LinkModal

--- a/frontend/src/components/LinkModal/styles.ts
+++ b/frontend/src/components/LinkModal/styles.ts
@@ -1,6 +1,10 @@
 import styled from "styled-components"
 
-import { H2, H3, P, ButtonOK } from "../globalStyles"
+import { Cover, H2, H3, P, ButtonOK } from "../globalStyles"
+
+export const LinkModalCover = styled(Cover)`
+  z-index: 9998;
+`
 
 export const Island = styled.div`
   width: 40%;

--- a/frontend/src/components/Room/index.tsx
+++ b/frontend/src/components/Room/index.tsx
@@ -151,7 +151,7 @@ const Room: React.FC<PropTypes> = ({
 
   const history = useHistory()
   const handleClose = (): void => {
-    const leaveRoomData: JoinLeaveRoomData = { roomID: id }
+    const leaveRoomData: RoomData = { roomID: id }
     socket.emit("leave room", leaveRoomData)
     history.push("/")
   }

--- a/frontend/src/components/Room/index.tsx
+++ b/frontend/src/components/Room/index.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, ReactElement } from "react"
-import { useHistory } from "react-router-dom"
+import { RouteComponentProps } from "react-router-dom"
+import { useHistory, withRouter } from "react-router-dom"
 
 // Utils, etc.
 import {
-  JoinLeaveRoomData,
+  RoomData,
   MouseMoveData,
   SyncDocData,
   SyncPageData,
@@ -17,24 +18,29 @@ import roundTo from "../../utils/roundTo"
 import NavBar, { PageOption } from "./NavBar"
 import PDFView from "../PDFView"
 import Pointer from "../Pointer"
+import { LocationState } from "../Home"
+import LinkModal from "../LinkModal"
 
 import { RoomBackground } from "./styles"
 
 const S3URL = "https://beam-me-up-scotty.s3.amazonaws.com"
 
+const roundTo2 = roundTo(2)
 enum ZOOMLIMIT {
   MIN = 1,
   MAX = 5,
 }
 
-type PropTypes = {
+interface PropTypes extends RouteComponentProps {
   id: string
-  originalFilename: string
+  filename: string
 }
 
-const roundTo2 = roundTo(2)
-
-const Room: React.FC<PropTypes> = ({ id, originalFilename }): ReactElement => {
+const Room: React.FC<PropTypes> = ({
+  id,
+  filename,
+  location,
+}): ReactElement => {
   const [maxPage, setMaxPage] = useState(1)
   const handleDocumentLoad = ({ numPages }): void => {
     setMaxPage(numPages)
@@ -94,7 +100,7 @@ const Room: React.FC<PropTypes> = ({ id, originalFilename }): ReactElement => {
   const [pdfFile, setPdfFile] = useState("")
   const [error, setError] = useState("")
   useEffect(() => {
-    const joinRoomData: JoinLeaveRoomData = { roomID: id }
+    const joinRoomData: RoomData = { roomID: id }
     socket.emit("join room", joinRoomData)
 
     socket.on("sync document", (data: SyncDocData): void => {
@@ -169,14 +175,22 @@ const Room: React.FC<PropTypes> = ({ id, originalFilename }): ReactElement => {
     )
   }
 
+  const renderModal = (): ReactElement => {
+    if (!location?.state) return null
+    return (location.state as LocationState).host ? (
+      <LinkModal link={window.location.toString()} />
+    ) : null
+  }
+
   const renderRoom = (): ReactElement => {
     return (
       <RoomBackground>
+        {renderModal()}
         {renderPointers()}
         <NavBar
           pageNum={pageNum}
           maxPage={maxPage}
-          filename={originalFilename}
+          filename={filename}
           users={users}
           showMouse={showMouse}
           handleChangePage={handleChangePage}
@@ -199,4 +213,4 @@ const Room: React.FC<PropTypes> = ({ id, originalFilename }): ReactElement => {
   return <div>{error ? `ERROR: ${error}` : renderRoom()}</div>
 }
 
-export default Room
+export default withRouter(Room) as any


### PR DESCRIPTION
## What does this PR fix?
- Fixes #50
- Fix types

## How?
- Room creator (host) joins room as soon as room is ready (socket sends private message when room is ready)
- Host can only invite others when room is ready
- Refactor `LinkModal` to be used without `Redirect` (only shows link or doesn't)
- Socket data types inherit from `RoomData` because they all send out `roomID`
