### PR TITLE
Fix zoom

### DIFF
--- a/frontend/src/components/DocumentView/styles.ts
+++ b/frontend/src/components/DocumentView/styles.ts
@@ -19,7 +19,7 @@ type PagePropType = {
 }
 
 export const Page = styled.img.attrs((props: PagePropType) => {
-  const height = `${props.scale * 100}%`
+  const transform = `scale(${props.scale})`
 
   let cursor = "default"
   if (props.scale > 1) {
@@ -28,13 +28,15 @@ export const Page = styled.img.attrs((props: PagePropType) => {
 
   return {
     style: {
-      height,
       cursor,
+      transform,
     },
   }
 })<PagePropType>`
   box-shadow: 0 0 1rem rgba(0, 0, 0, 0.25);
   margin: auto;
+  max-height: 100%;
   object-fit: contain;
   background-color: white;
+  transform-origin: top;
 `

--- a/frontend/src/components/Room/index.tsx
+++ b/frontend/src/components/Room/index.tsx
@@ -62,7 +62,6 @@ const Room: React.FC<PropTypes> = ({
 
   const [scale, setScale] = useState(1)
   const handleZoom = (offset: number): void => {
-    console.log(offset, ZOOMLIMIT.MIN)
     setScale(prev => {
       return prev + offset < ZOOMLIMIT.MIN || prev + offset > ZOOMLIMIT.MAX
         ? prev


### PR DESCRIPTION
## What does this PR fix?
- Fixes #63 

## How?
- Use `transform: scale()` to emulate zooming.
- Image `height` and `max-height` stays the same regardless of scale.
