### PR TITLE
Fix zoom

### DIFF
--- a/frontend/src/components/DocumentView/index.tsx
+++ b/frontend/src/components/DocumentView/index.tsx
@@ -97,7 +97,7 @@ const View: FC<PropTypes> = ({ src, scale, pageRef }): ReactElement => {
   }, [scale])
 
   return (
-    <DocumentContainer ref={docRef} scale={scale}>
+    <DocumentContainer ref={docRef}>
       <PageContainer
         scale={scale}
         mouseDown={mouseDown}

--- a/frontend/src/components/DocumentView/index.tsx
+++ b/frontend/src/components/DocumentView/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
   RefObject,
   useRef,
+  useEffect,
 } from "react"
 
 import { DocumentContainer, PageContainer, Page } from "./styles"
@@ -16,7 +17,7 @@ type PropTypes = {
 }
 
 const View: FC<PropTypes> = ({ src, scale, pageRef }): ReactElement => {
-  const containerRef = useRef(null)
+  const docRef = useRef(null)
   const handleContextMenu = (ev: MouseEvent): void => {
     ev.preventDefault()
   }
@@ -39,10 +40,13 @@ const View: FC<PropTypes> = ({ src, scale, pageRef }): ReactElement => {
     }
   }
 
+  // default is center (0.5 of width and height)
+  const [scrollLeftRatio, setScrollLeftRatio] = useState(0.5)
+  const [scrollTopRatio, setScrollTopRatio] = useState(0.5)
   const handlePan = (ev: MouseEvent): void => {
     if (!mouseDown || scale <= 1) return
 
-    const containerElmt = containerRef.current
+    const containerElmt = docRef.current
 
     let deltaX = startX - ev.clientX
     let deltaY = startY - ev.clientY
@@ -54,24 +58,56 @@ const View: FC<PropTypes> = ({ src, scale, pageRef }): ReactElement => {
 
     setStartX(ev.clientX)
     setStartY(ev.clientY)
+
+    if (docRef.current) {
+      const {
+        scrollLeft,
+        scrollWidth,
+        clientWidth,
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+      } = docRef.current
+
+      const scrollLeftMax = scrollWidth - clientWidth
+      const scrollTopMax = scrollHeight - clientHeight
+
+      setScrollLeftRatio(scrollLeft / scrollLeftMax)
+      setScrollTopRatio(scrollTop / scrollTopMax)
+    }
   }
 
+  useEffect(() => {
+    if (scale === 1) {
+      setScrollLeftRatio(0.5)
+      setScrollTopRatio(0.5)
+    }
+
+    const {
+      scrollWidth,
+      clientWidth,
+      scrollHeight,
+      clientHeight,
+    } = docRef.current
+    const scrollLeftMax = scrollWidth - clientWidth
+    const scrollTopMax = scrollHeight - clientHeight
+
+    docRef.current.scrollLeft = scrollLeftMax * scrollLeftRatio
+    docRef.current.scrollTop = scrollTopMax * scrollTopRatio
+  }, [scale])
+
   return (
-    <DocumentContainer ref={containerRef} scale={scale}>
+    <DocumentContainer ref={docRef} scale={scale}>
       <PageContainer
+        scale={scale}
+        mouseDown={mouseDown}
         onContextMenu={handleContextMenu}
         onMouseMove={handlePan}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseReset}
         onMouseLeave={handleMouseReset}
       >
-        <Page
-          src={src}
-          ref={pageRef}
-          scale={scale}
-          mouseDown={mouseDown}
-          draggable={false}
-        />
+        <Page src={src} ref={pageRef} draggable={false} />
       </PageContainer>
     </DocumentContainer>
   )

--- a/frontend/src/components/DocumentView/index.tsx
+++ b/frontend/src/components/DocumentView/index.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
 } from "react"
 
-import { DocumentContainer, Page } from "./styles"
+import { DocumentContainer, PageContainer, Page } from "./styles"
 
 type PropTypes = {
   src: string
@@ -58,18 +58,21 @@ const View: FC<PropTypes> = ({ src, scale, pageRef }): ReactElement => {
 
   return (
     <DocumentContainer ref={containerRef} scale={scale}>
-      <Page
-        ref={pageRef}
-        src={src}
-        scale={scale}
-        mouseDown={mouseDown}
+      <PageContainer
         onContextMenu={handleContextMenu}
-        draggable={false}
         onMouseMove={handlePan}
         onMouseDown={handleMouseDown}
         onMouseUp={handleMouseReset}
         onMouseLeave={handleMouseReset}
-      />
+      >
+        <Page
+          src={src}
+          ref={pageRef}
+          scale={scale}
+          mouseDown={mouseDown}
+          draggable={false}
+        />
+      </PageContainer>
     </DocumentContainer>
   )
 }

--- a/frontend/src/components/DocumentView/styles.ts
+++ b/frontend/src/components/DocumentView/styles.ts
@@ -1,31 +1,22 @@
 import styled from "styled-components"
 
-type ContainerPropType = {
+type ContainerProp = {
   scale: number
 }
 
-export const DocumentContainer = styled.div<ContainerPropType>`
+export const DocumentContainer = styled.div<ContainerProp>`
   margin: 3rem auto 0 auto;
   height: calc(100vh - 3rem);
   width: 100vw;
-  display: flex;
-  overflow: ${(props): string => (props.scale <= 1 ? "hidden" : "scroll")};
+  overflow: scroll;
 `
 
-export const PageContainer = styled.div`
-  box-sizing: border-box;
-  margin: auto;
-  padding: 2rem;
-  height: 100%;
-  display: flex;
-`
-
-type PagePropType = {
+type PageContainerProp = {
   scale: number
   mouseDown: boolean
 }
 
-export const Page = styled.img.attrs((props: PagePropType) => {
+export const PageContainer = styled.div.attrs((props: PageContainerProp) => {
   const transform = `scale(${props.scale})`
 
   let cursor = "default"
@@ -39,12 +30,20 @@ export const Page = styled.img.attrs((props: PagePropType) => {
       transform,
     },
   }
-})<PagePropType>`
+})<PageContainerProp>`
+  box-sizing: border-box;
+  margin: auto;
+  padding: 2rem;
+  height: 100%;
+  display: flex;
+  transform-origin: top left;
+`
+
+export const Page = styled.img`
   margin: auto;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   background-color: white;
   box-shadow: 0 0 1rem rgba(0, 0, 0, 0.25);
-  transform-origin: top left;
 `

--- a/frontend/src/components/DocumentView/styles.ts
+++ b/frontend/src/components/DocumentView/styles.ts
@@ -1,10 +1,6 @@
 import styled from "styled-components"
 
-type ContainerProp = {
-  scale: number
-}
-
-export const DocumentContainer = styled.div<ContainerProp>`
+export const DocumentContainer = styled.div`
   margin: 3rem auto 0 auto;
   height: calc(100vh - 3rem);
   width: 100vw;

--- a/frontend/src/components/DocumentView/styles.ts
+++ b/frontend/src/components/DocumentView/styles.ts
@@ -5,12 +5,19 @@ type ContainerPropType = {
 }
 
 export const DocumentContainer = styled.div<ContainerPropType>`
-  margin: 2.5rem auto 0 auto;
-  padding: 2rem;
-  height: calc(100vh - 6.5rem);
+  margin: 3rem auto 0 auto;
+  height: calc(100vh - 3rem);
   width: 100vw;
   display: flex;
   overflow: ${(props): string => (props.scale <= 1 ? "hidden" : "scroll")};
+`
+
+export const PageContainer = styled.div`
+  box-sizing: border-box;
+  margin: auto;
+  padding: 2rem;
+  height: 100%;
+  display: flex;
 `
 
 type PagePropType = {
@@ -33,11 +40,11 @@ export const Page = styled.img.attrs((props: PagePropType) => {
     },
   }
 })<PagePropType>`
-  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.25);
   margin: auto;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   background-color: white;
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.25);
   transform-origin: top left;
 `

--- a/frontend/src/components/Room/index.tsx
+++ b/frontend/src/components/Room/index.tsx
@@ -74,13 +74,21 @@ const Room: React.FC<PropTypes> = ({
   const handleMouseMove = (ev?: MouseEvent): void => {
     if (!pageRef.current) return
 
-    const { offsetLeft, clientWidth, offsetTop, clientHeight } = pageRef.current
+    const {
+      offsetLeft,
+      clientWidth,
+      offsetTop,
+      clientHeight,
+      offsetParent,
+    } = pageRef.current
 
     const mouseX: number = ev
       ? roundTo3((ev.clientX - offsetLeft) / clientWidth)
       : null
     const mouseY: number = ev
-      ? roundTo3((ev.clientY - offsetTop) / clientHeight)
+      ? roundTo3(
+          (ev.clientY - offsetTop - offsetParent.offsetTop) / clientHeight
+        )
       : null
 
     const mouseMoveData: MouseMoveData = {
@@ -167,10 +175,12 @@ const Room: React.FC<PropTypes> = ({
               offsetTop,
               clientWidth,
               clientHeight,
+              offsetParent,
             } = pageRef.current
 
             const mouseX = offsetLeft + user.mouseX * clientWidth
-            const mouseY = offsetTop + user.mouseY * clientHeight
+            const mouseY =
+              offsetTop + offsetParent.offsetTop + user.mouseY * clientHeight
 
             return (
               <Pointer


### PR DESCRIPTION
## What does this PR fix?
- Fixes lack of padding around `Page` when zooming in.
- First implementation of #65, but it's a little choppy.

## How?
- Wrap `Page` component in `PageContainer`, and scale that component on zoom
- Calculate scroll ratio on pan and use ratio to calculate scroll destination after zoom/scale.
