### PR TITLE
Non lazy loading

### DIFF
--- a/frontend/src/components/DocumentView/index.tsx
+++ b/frontend/src/components/DocumentView/index.tsx
@@ -1,18 +1,25 @@
-import React, { FC, ReactElement, RefObject, useRef } from "react"
+import React, { FC, ReactElement, RefObject, useRef, useEffect } from "react"
 import { connect } from "react-redux"
+import { Dispatch } from "redux"
 
 import { DocumentContainer, PageContainer, Page } from "./styles"
-
 import usePanhandler from "./hooks/usePanhandler"
+import { cachePage } from "../../store/actions"
+import { PageCache } from "../../store/types"
 
 type PropTypes = {
   pageRef: RefObject<HTMLImageElement>
 }
 
-const View: FC<PropTypes & StateProps> = ({
+const View: FC<PropTypes & StateProps & DispatchProps> = ({
   pageRef,
   zoom,
+  pdfUrl,
   pageUrl,
+  nextPageFile,
+  nextNextPageFile,
+  cachedPages,
+  cachePage,
 }): ReactElement => {
   const docRef = useRef(null)
   const {
@@ -22,6 +29,25 @@ const View: FC<PropTypes & StateProps> = ({
     handleMouseReset,
     handlePan,
   } = usePanhandler(docRef, zoom)
+
+  useEffect(() => {
+    // Load next 2 pages to be loaded if not cached yet
+    // on p1 -> load 2, 3
+    // on p2 -> load 4, 5
+    // on p3 -> load 6, 7, etc.
+
+    if (nextPageFile && !cachedPages[nextPageFile]) {
+      const nextPage = new Image()
+      nextPage.src = `${pdfUrl}/${nextPageFile}`
+      cachePage(nextPageFile)
+    }
+
+    if (nextNextPageFile && !cachedPages[nextNextPageFile]) {
+      const nextNextPage = new Image()
+      nextNextPage.src = `${pdfUrl}/${nextNextPageFile}`
+      cachePage(nextNextPageFile)
+    }
+  }, [pdfUrl, nextPageFile, nextNextPageFile])
 
   return (
     <DocumentContainer ref={docRef}>
@@ -43,15 +69,33 @@ const View: FC<PropTypes & StateProps> = ({
 type StateProps = {
   zoom: number
   pageUrl: string
+  nextPageFile: string
+  nextNextPageFile: string
+  pdfUrl: string
+  cachedPages: PageCache
 }
 
 const mapStateToProps = ({
   zoom,
-  pages: { pages, currentPage },
+  pages: { pages, currentPage, cached },
   room: { pdfUrl },
 }): StateProps => ({
   zoom,
+  pdfUrl,
   pageUrl: `${pdfUrl}/${pages[currentPage - 1]}`,
+  nextPageFile: pages[currentPage + currentPage - 1],
+  nextNextPageFile: pages[currentPage + currentPage],
+  cachedPages: cached,
 })
 
-export default connect(mapStateToProps)(View)
+type DispatchProps = {
+  cachePage(page: string): void
+}
+
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  cachePage(page): void {
+    dispatch(cachePage(page))
+  },
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(View)

--- a/frontend/src/store/actions.ts
+++ b/frontend/src/store/actions.ts
@@ -79,6 +79,11 @@ export const clearPages = (): PagesAction => ({
   type: constants.CLEAR_PAGES,
 })
 
+export const cachePage = (page: string): PagesAction => ({
+  type: constants.CACHE_PAGE,
+  page,
+})
+
 /////////////////////
 //      Tools      //
 /////////////////////

--- a/frontend/src/store/constants.ts
+++ b/frontend/src/store/constants.ts
@@ -10,6 +10,7 @@ export const SET_ZOOM_LEVEL = "SET_ZOOM_LEVEL"
 export const GO_TO_PAGE = "GO_TO_PAGE"
 export const SET_PAGES = "SET_PAGES"
 export const CLEAR_PAGES = "CLEAR_PAGES"
+export const CACHE_PAGE = "CACHE_PAGE"
 
 // Tools
 export const SELECT_TOOL = "SELECT_TOOL"

--- a/frontend/src/store/reducers.ts
+++ b/frontend/src/store/reducers.ts
@@ -36,6 +36,7 @@ const zoomReducer = (state = 1, action: types.ZoomAction): number => {
 const initialPageState: types.PageState = {
   currentPage: 1,
   pages: [],
+  cached: {},
 }
 
 const pagesReducer = (
@@ -49,6 +50,8 @@ const pagesReducer = (
       return { ...state, currentPage: action.pageNum }
     case constants.CLEAR_PAGES:
       return initialPageState
+    case constants.CACHE_PAGE:
+      return { ...state, cached: { ...state.cached, [action.page]: true } }
     default:
       return state
   }

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -43,7 +43,16 @@ type ClearPagesAction = {
   type: typeof constants.CLEAR_PAGES
 }
 
-export type PagesAction = GoToPageAction | SetPagesAction | ClearPagesAction
+type CachePageAction = {
+  type: typeof constants.CACHE_PAGE
+  page: string
+}
+
+export type PagesAction =
+  | GoToPageAction
+  | SetPagesAction
+  | ClearPagesAction
+  | CachePageAction
 
 type SelectToolAction = {
   type: typeof constants.SELECT_TOOL
@@ -66,9 +75,14 @@ export type RoomState = {
   pdfUrl: string
 }
 
+export type PageCache = {
+  [pageFile: string]: boolean
+}
+
 export type PageState = {
   currentPage: number
   pages: string[]
+  cached: PageCache
 }
 
 export type ToolState = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scotty",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "WebSocket-enabled PDF viewer",
   "main": "backend/index.js",
   "engines": {


### PR DESCRIPTION
## What does this PR fix?
- Fixes #56 

## How?
- Load the next 2 pages to be loaded if not cached:
    - on page 1, load pages 2 & 3; on page 2, load pages 4 & 5; on page 3, load pages 6 & 7, etc.
- Cache pages that have been loaded in redux store so we're not doing unnecessary work
